### PR TITLE
Changed casing of ionCheckbox class to match casing of file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prebuild": "rm -rf dist && mkdir dist && mkdir dist/scss",
     "build:babel": "babel src --out-dir dist",
     "build:assets": "cp -a src/ionic-scss src/styles src/fonts dist/scss/.",
-    "build": "npm run build:assets && npm run build:babel"
+    "build": "npm run build:assets && npm run build:babel",
+    "postinstall": "npm run build && rm -r node_modules"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import IonBody from './components/ionBody';
 import IonButton from './components/ionButton';
 import IonCard from './components/ionCard';
 import IonContent from './components/ionContent';
-import IonCheckbox from './components/ionCheckbox';
+import IonCheckBox from './components/ionCheckBox';
 import IonFooterBar from './components/ionFooterBar';
 import IonHeaderBar from './components/ionHeaderBar';
 import IonIcon from './components/ionIcon';
@@ -44,7 +44,7 @@ module.exports = {
   IonButton: IonButton,
   IonCard: IonCard,
   IonContent: IonContent,
-  IonCheckbox: IonCheckbox,
+  IonCheckBox: IonCheckBox,
   IonFooterBar: IonFooterBar,
   IonHeaderBar: IonHeaderBar,
   IonIcon: IonIcon,


### PR DESCRIPTION
This is related to a project I was working on that had case sensitive paths. This is a simple fix by just changing the casing of `IonCheckbox` to `IonCheckBox` to match the jsx file name. This also makes the class names more logically consistent. 